### PR TITLE
🧹 Remove unused `jinja2` import

### DIFF
--- a/rke2-versions.py
+++ b/rke2-versions.py
@@ -5,7 +5,6 @@ import os
 import requests
 import sys
 import re
-import jinja2
 
 from datetime import datetime
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unused `jinja2` import in `rke2-versions.py`.
💡 **Why:** Removing unused imports improves the maintainability and readability of the codebase by getting rid of unnecessary dependencies and clutter.
✅ **Verification:** Ran `python3 rke2-versions.py` locally and ensured the script executed successfully without the removed import, throwing no exceptions. Tested the functionality to ensure it behaved identically to before the change.
✨ **Result:** A cleaner `rke2-versions.py` script with one fewer unnecessary import.

---
*PR created automatically by Jules for task [495467753269075831](https://jules.google.com/task/495467753269075831) started by @e-minguez*